### PR TITLE
Add LaunchMe vs Raycast comparison post

### DIFF
--- a/blog/data/comparison-data.json
+++ b/blog/data/comparison-data.json
@@ -16,13 +16,10 @@
     ["Hide Apps", "Pro"],
     ["Save Layouts", "Free"],
     ["Sort apps A-Z", "Free"],
-    ["Change icons size", "Free"],
     ["Auto System Icon Style", "Free"],
-    ["Auto Dark / Light Theme", "Free"],
     ["Page with Categories", "Free"],
-    ["Free Layout Grid", "Free"],
-    ["Snow animation", "Free"],
-    ["Glass or Flat themes", "Pro"]
+    ["Customizable Grid with apps", "Free"],
+    ["Extensions ecosystem", "–"]
   ],
   "competitors": {
     "launchie": {
@@ -45,7 +42,6 @@
       "name": "AppHub",
       "overrides": {
         "Hot Corners": "PAID",
-        "Change icons size": "PAID",
         "Hide Apps": "PAID"
       }
     },
@@ -54,7 +50,6 @@
       "overrides": {
         "Gesture Invoke": "PAID",
         "Save Layouts": "PAID",
-        "Change icons size": "PAID",
         "Auto System Icon Style": "PAID"
       }
     },
@@ -75,6 +70,15 @@
         "Hide Apps": "PAID"
       }
     },
-    "udock": { "name": "Udock" }
+    "udock": { "name": "Udock" },
+    "raycast": {
+      "name": "Raycast",
+      "overrides": {
+        "Search Files": "Free",
+        "Calculator": "Free",
+        "Clipboard": "Pro",
+        "Extensions ecosystem": "Yes"
+      }
+    }
   }
 }

--- a/blog/index.html
+++ b/blog/index.html
@@ -96,6 +96,19 @@
                 </article>
 
                 <article class="blog-card" style="margin-top: 20px">
+                    <a class="blog-card__inner" href="/blog/launchme-vs-raycast.html" style="display:grid;gap:24px;background:#f9fbff;border-radius:40px;color:#000;text-decoration:none;padding:20px 24px;box-shadow:0 18px 50px rgba(0,0,0,0.4);">
+                        <div class="blog-card__thumb"><img src="../images/comparison-img.jpg" alt="LaunchMe vs Raycast comparison" style="width:100%;height:100%;object-fit:cover;border-radius:26px;display:block;"></div>
+                        <div class="blog-card__content" style="display:flex;flex-direction:column;justify-content:space-between;">
+                            <h2 class="blog-card__title" style="margin:4px 0 8px;font-size:24px;font-weight:800;color:#000;">LaunchMe vs Raycast</h2>
+                            <p class="blog-card__excerpt" style="margin:0;font-size:14px;line-height:1.6;color:#333;max-width:460px;">Compare LaunchMe and Raycast: visual app grid launcher vs keyboard command palette. Spaces, Workflows, pricing, and which fits macOS 26 Tahoe.</p>
+                            <div class="blog-card__footer" style="display:flex;justify-content:space-between;align-items:center;margin-top:16px;font-size:13px;">
+                                <span class="blog-card__read" style="font-weight:600;color:#000;">Read article</span>
+                                <span class="blog-card__meta" style="color:#555;">Last updated: Mar 3, 2026 · 6 min read</span>
+                            </div>
+                        </div>
+                    </a>
+                </article>
+                <article class="blog-card" style="margin-top: 20px">
                     <a class="blog-card__inner" href="/blog/launchme-vs-launchie.html" style="display:grid;gap:24px;background:#f9fbff;border-radius:40px;color:#000;text-decoration:none;padding:20px 24px;box-shadow:0 18px 50px rgba(0,0,0,0.4);">
                         <div class="blog-card__thumb"><img src="../images/comparison-img.jpg" alt="LaunchMe vs Launchie comparison" style="width:100%;height:100%;object-fit:cover;border-radius:26px;display:block;"></div>
                         <div class="blog-card__content" style="display:flex;flex-direction:column;justify-content:space-between;">
@@ -214,6 +227,7 @@
                     <ul class="help-nav-list blog-nav-list">
                         <li><a href="/blog/launchme-update-1-111.html" class="help-nav-link">LaunchMe Update 1.111 — New Features</a></li>
                         <li><a href="/blog/how-to-get-launchpad-back-on-macos-26-tahoe.html" class="help-nav-link">How to Get Launchpad Back on macOS 26 Tahoe</a></li>
+                        <li><a href="/blog/launchme-vs-raycast.html" class="help-nav-link">LaunchMe vs Raycast</a></li>
                         <li><a href="/blog/launchme-vs-launchie.html" class="help-nav-link">LaunchMe vs Launchie</a></li>
                         <li><a href="/blog/launchme-vs-appgrid.html" class="help-nav-link">LaunchMe vs AppGrid</a></li>
                         <li><a href="/blog/launchme-vs-launchos.html" class="help-nav-link">LaunchMe vs LaunchOS</a></li>

--- a/blog/launchme-vs-raycast.html
+++ b/blog/launchme-vs-raycast.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>LaunchMe vs Raycast - Best Mac App Launcher for macOS 26 | LaunchMe</title>
+
+    <!-- Primary SEO metadata: comparison article for search and AI indexing -->
+    <!-- SEO: 110-160 chars. -->
+    <meta name="description" content="LaunchMe vs Raycast: compare visual app launcher vs command palette for macOS 26. Features, pricing, Spaces, Workflows, and which fits your workflow.">
+    <meta name="keywords" content="LaunchMe vs Raycast, Raycast alternative, Mac app launcher comparison, Launchpad replacement macOS 26, Raycast free vs paid, best Mac launcher 2026">
+    <link rel="canonical" href="https://launchmeapp.com/blog/launchme-vs-raycast.html">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="LaunchMe vs Raycast - Best Mac App Launcher for macOS 26 | LaunchMe">
+    <meta property="og:description" content="LaunchMe vs Raycast: compare visual app grid launcher vs keyboard command palette. Find out which tool wins for macOS 26 Tahoe workflows.">
+    <meta property="og:url" content="https://launchmeapp.com/blog/launchme-vs-raycast.html">
+    <meta property="og:image" content="https://launchmeapp.com/images/comparison-img.jpg">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="LaunchMe vs Raycast - Best Mac App Launcher for macOS 26 | LaunchMe">
+    <meta name="twitter:description" content="LaunchMe vs Raycast: visual launcher vs command palette. Compare Spaces, Workflows, customization, and pricing for macOS 26 Tahoe.">
+    <meta name="twitter:image" content="https://launchmeapp.com/images/comparison-img.jpg">
+
+    <!-- Icons + styles (paths relative to blog/ folder) -->
+    <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="../images/favicon.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../images/apple-touch-icon.png">
+    <link rel="stylesheet" href="../css/style.css?v=3">
+
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FCPNZRQH0"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-0FCPNZRQH0');
+    </script>
+
+    <!-- Article structured data (JSON-LD) for SEO and AI -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "LaunchMe vs Raycast - Best Mac App Launcher for macOS 26 | LaunchMe",
+      "description": "Compare LaunchMe and Raycast: visual app launcher vs command palette, features, pricing, and which wins for macOS 26 Tahoe workflows.",
+      "datePublished": "2026-03-03",
+      "dateModified": "2026-03-03",
+      "image": "https://launchmeapp.com/images/comparison-img.jpg",
+      "author": { "@type": "Organization", "name": "LaunchMe" },
+      "publisher": {
+        "@type": "Organization",
+        "name": "LaunchMe",
+        "logo": { "@type": "ImageObject", "url": "https://launchmeapp.com/images/logoicontext.png" }
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://launchmeapp.com/blog/launchme-vs-raycast.html"
+      }
+    }
+    </script>
+</head>
+<body class="doc blog article-page">
+    <header class="site-header minimal">
+        <div class="container header-inner">
+            <a class="brand" href="/"><img class="brand-img" src="../images/logoicontext.png" alt="LaunchMe"></a>
+        </div>
+    </header>
+
+    <main class="help-main blog-main container article-main">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+            <a href="/">Home</a>
+            <span class="breadcrumbs-separator">/</span>
+            <a href="index.html">Blog</a>
+            <span class="breadcrumbs-separator">/</span>
+            <span aria-current="page">LaunchMe vs Raycast. Best Mac App Launcher for macOS 26</span>
+        </nav>
+
+        <div class="help-layout blog-layout">
+            <div class="help-content">
+                <article class="blog-article article-page-article" itemscope itemtype="https://schema.org/Article">
+                    <figure class="help-image-placeholder" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                        <img src="../images/comparison-img.jpg" alt="LaunchMe vs Raycast comparison" class="help-image" itemprop="url">
+                        <figcaption class="blog-image-caption">LaunchMe vs Raycast: visual app launcher vs keyboard command palette for macOS 26 Tahoe.</figcaption>
+                    </figure>
+
+                    <header>
+                        <h1 itemprop="headline">LaunchMe vs Raycast. Best Mac App Launcher for macOS 26</h1>
+                        <p class="blog-meta">
+                            <time datetime="2026-03-03" itemprop="datePublished">Last updated: Mar 3, 2026</time>
+                        </p>
+                    </header>
+
+                    <p class="blog-intro">
+                        People often ask which is better — <strong>LaunchMe or Raycast</strong>. The honest answer is that they're not really the same type of app.
+                        But if you're looking for a Launchpad replacement on macOS 26 Tahoe, this comparison will save you time.
+                    </p>
+
+                    <h2>LaunchMe vs Raycast: the core difference</h2>
+                    <p>
+                        <strong>Raycast</strong> is a keyboard-driven command palette. Press a hotkey, type a command or app name, and Raycast runs it.
+                        It's designed for people who keep their hands on the keyboard and want to control their Mac through text commands.
+                        It also has an extension store where you can connect Slack, GitHub, Linear, Notion, and many other tools.
+                    </p>
+                    <p>
+                        <strong>LaunchMe</strong> is a visual app grid launcher — built to replace macOS Launchpad.
+                        You open it with a hotkey, Hot Corner, or trackpad gesture, and you get a fully customizable grid of your apps.
+                        Organize them into folders and pages, add widgets, switch between saved Spaces for different setups,
+                        or launch a whole set of apps at once with Workflows.
+                    </p>
+                    <p>
+                        Raycast is for people who think in commands. LaunchMe is for people who want a fast visual home base for their Mac.
+                    </p>
+
+                    <h2>Feature comparison table</h2>
+                    <p>
+                        The table below shows what LaunchMe offers (Free and Pro) versus Raycast.
+                        A lot of launcher-specific features simply aren't in Raycast — it's a different kind of tool.
+                    </p>
+
+                    <!-- Comparison table rendered from data/comparison-data.json -->
+                    <div data-comparison-table data-competitor="raycast"></div>
+
+                    <p>
+                        Sources:
+                        <a class="faq-link" href="https://apps.apple.com/app/apple-store/id6751939046?pt=128114906&ct=Website&mt=8">LaunchMe on Mac App Store</a>,
+                        <a class="faq-link" href="https://www.raycast.com">Raycast official website</a>,
+                        <a class="faq-link" href="https://www.raycast.com/pro">Raycast Pro page</a>.
+                    </p>
+
+                    <h2>Where Raycast is limited compared to LaunchMe</h2>
+
+                    <h3>No visual app grid — Raycast isn't a Launchpad replacement</h3>
+                    <p>
+                        Raycast doesn't show a visual grid of your apps — it's a search bar, not a launcher screen.
+                        If you upgraded to macOS 26 Tahoe and lost Launchpad, Raycast won't fill that gap.
+                        LaunchMe was built for exactly that job.
+                    </p>
+
+                    <h3>No Spaces — no way to save and switch between full setups</h3>
+                    <p>
+                        LaunchMe <strong>Spaces</strong> let you save your entire setup — apps, layout, widgets, wallpaper — as a named Space.
+                        Switch between Work, Gaming, or Personal mode with one hotkey, or schedule it to change automatically by time of day.
+                        Raycast has nothing like this.
+                    </p>
+
+                    <h3>No Workflows — no one-click multi-app launch</h3>
+                    <p>
+                        LaunchMe <strong>Workflows</strong> open a whole set of apps and folders with a single click.
+                        Each Workflow has a custom name and icon and acts like a regular app in your grid.
+                        Raycast has Script Commands that can do something similar, but you need to write scripts to set them up.
+                    </p>
+
+                    <h3>No dynamic wallpapers</h3>
+                    <p>
+                        LaunchMe has two animated wallpapers built in.
+                        The <strong>Dynamic Sun wallpaper</strong> moves the sun across the sky based on your local time — sunrise, daytime, sunset, night with stars.
+                        The <strong>Dynamic Weather wallpaper</strong> pulls real weather data for any city and changes the scene to match: clear, cloudy, rain, thunderstorm, or snow.
+                        Raycast has no wallpaper system.
+                    </p>
+
+                    <h3>No themes, widgets, or custom icons</h3>
+                    <p>
+                        LaunchMe has Glass and Flat themes, custom app icons (any PNG or JPG), a set of Clear Colored icons,
+                        and widgets for Calendar, Photo, GIF, Text, and Animations.
+                        Raycast does have custom themes, but it's a Pro-only feature ($8/month+).
+                        LaunchMe Pro is available as a one-time Lifetime purchase.
+                    </p>
+
+                    <h3>Raycast is keyboard-only — no Hot Corners or gestures</h3>
+                    <p>
+                        LaunchMe opens with a hotkey, a Hot Corner, or a trackpad gesture — all free.
+                        Raycast only works with a keyboard shortcut.
+                    </p>
+
+                    <h3>Clipboard History is behind Raycast's paywall</h3>
+                    <p>
+                        Raycast lists "unlimited Clipboard History" as a Pro feature.
+                        In LaunchMe it's free — text, images, files, and links, all saved automatically.
+                    </p>
+
+                    <h3>Raycast isn't on the Mac App Store</h3>
+                    <p>
+                        Raycast is distributed outside the App Store. LaunchMe goes through Apple's review and privacy checks.
+                        That matters if you care about what permissions an app can request and how updates are vetted.
+                    </p>
+
+                    <h2>Where Raycast wins over LaunchMe</h2>
+                    <ul>
+                        <li><strong>Extensions ecosystem</strong>: Raycast has thousands of community extensions — Slack, GitHub, Linear, Notion, and much more. LaunchMe doesn't try to compete here; it's focused on the launcher itself.</li>
+                        <li><strong>AI assistant</strong>: Raycast Pro has an AI chat that can answer questions, draft text, and run automations. LaunchMe doesn't have this yet — but <strong>Ask AI</strong> is coming in a future update, as on-device AI with no queries sent outside your Mac.</li>
+                        <li><strong>Quicklinks and Snippets</strong>: useful if you spend most of your day navigating URLs or reusing text blocks.</li>
+                        <li><strong>Window Management</strong>: Raycast Pro can resize and arrange windows. LaunchMe doesn't do this — it's a launcher, not a window manager.</li>
+                    </ul>
+                    <p>
+                        If integrations and keyboard commands are your whole workflow, Raycast is probably the better fit for that.
+                        But if you need a proper app launcher that replaces Launchpad and gives you real visual control over your setup, LaunchMe does the job Raycast can't.
+                    </p>
+
+                    <h2>Pricing comparison</h2>
+                    <p>
+                        Raycast is free at the base level, but most of what makes it powerful — AI, Clipboard History, Cloud Sync, Custom Themes, Window Management — sits behind a Pro subscription starting at <strong>$8/month</strong>. No lifetime option, subscription only.
+                    </p>
+                    <p>
+                        LaunchMe has a solid free tier that covers daily use. The Pro plan unlocks themes, widgets, live wallpapers, custom icons, Spaces, and Workflows.
+                        You can pay <strong>Monthly</strong>, <strong>Yearly</strong>, or buy a <strong>Lifetime</strong> license once and be done with it.
+                        There's also a 7-day free trial to test Pro before you commit.
+                    </p>
+
+                    <h2>Why LaunchMe is the better Launchpad replacement for macOS 26</h2>
+                    <ul>
+                        <li><strong>Visual app grid</strong>: replaces macOS Launchpad with a richer, fully customizable grid interface.</li>
+                        <li><strong>Spaces</strong>: switch between complete desktop setups (work, gaming, personal) in one click.</li>
+                        <li><strong>Workflows</strong>: launch multiple apps and folders at once with a single automation preset.</li>
+                        <li><strong>Dynamic wallpapers</strong>: animated Sun and Weather backgrounds that react to real time and real weather.</li>
+                        <li><strong>Hot Corners and gestures (Free)</strong>: invoke the launcher without lifting your hands off the trackpad.</li>
+                        <li><strong>Clipboard in Free tier</strong>: no paywall for copying and pasting your recent history.</li>
+                        <li><strong>Mac App Store</strong>: trusted distribution with Apple privacy review.</li>
+                        <li><strong>Lifetime purchase option</strong>: pay once, no monthly subscription required.</li>
+                    </ul>
+
+                    <h2>Multi-language support</h2>
+                    <p>
+                        LaunchMe is available in <strong>11 languages</strong>: English, Chinese, Japanese, Korean, German, Italian, Spanish, Russian,
+                        Portuguese, Hindi, and Turkish.
+                    </p>
+
+                    <h2>Verdict</h2>
+                    <p>
+                        These two apps don't really compete for the same user. Raycast is a command bar for keyboard-first workflows and developer integrations.
+                        LaunchMe is a visual app launcher for people who want a proper home base on their Mac — with organization, customization, and real automation built in.
+                    </p>
+                    <p>
+                        If you lost Launchpad after upgrading to macOS 26 Tahoe and want something better, LaunchMe is the right pick.
+                        Raycast won't replace that. LaunchMe will.
+                    </p>
+
+                    <p>
+                        You can download LaunchMe on the
+                        <a class="faq-link" href="https://apps.apple.com/app/apple-store/id6751939046?pt=128114906&ct=Website&mt=8">Mac App Store</a>
+                        and try Pro features free for 7 days.
+                    </p>
+
+                    <footer class="blog-tags">
+                        <span>LaunchMe</span>
+                        <span>Raycast</span>
+                        <span>Comparison</span>
+                        <span><a href="/">Mac app launcher</a></span>
+                    </footer>
+                </article>
+            </div>
+
+            <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
+                <section class="blog-subscribe" style="margin-bottom: 20px;">
+                    <a class="app-badge" href="https://apps.apple.com/app/apple-store/id6751939046?pt=128114906&ct=Website&mt=8">
+                        <img src="../images/app-store-badge.svg" alt="Download LaunchMe on the Mac App Store">
+                    </a>
+                </section>
+
+                <nav class="help-nav blog-nav" aria-label="Blog navigation">
+                    <h2 class="blog-nav-title">Articles</h2>
+                    <ul class="help-nav-list blog-nav-list">
+                        <li><a href="launchme-update-1-111.html" class="help-nav-link">LaunchMe Update 1.111 — New Features</a></li>
+                        <li><a href="how-to-get-launchpad-back-on-macos-26-tahoe.html" class="help-nav-link">How to Get Launchpad Back on macOS 26 Tahoe</a></li>
+                        <li><a href="launchme-vs-raycast.html" class="help-nav-link" aria-current="page">LaunchMe vs Raycast</a></li>
+                        <li><a href="launchme-vs-launchie.html" class="help-nav-link">LaunchMe vs Launchie</a></li>
+                        <li><a href="launchme-vs-appgrid.html" class="help-nav-link">LaunchMe vs AppGrid</a></li>
+                        <li><a href="launchme-vs-launchos.html" class="help-nav-link">LaunchMe vs LaunchOS</a></li>
+                        <li><a href="launchme-vs-hotlaunch.html" class="help-nav-link">LaunchMe vs HotLaunch</a></li>
+                        <li><a href="launchme-vs-folderx.html" class="help-nav-link">LaunchMe vs FolderX</a></li>
+                        <li><a href="launchme-vs-apphub.html" class="help-nav-link">LaunchMe vs AppHub</a></li>
+                        <li><a href="launchme-vs-qal-pro.html" class="help-nav-link">LaunchMe vs QAL Pro</a></li>
+                        <li><a href="launchme-vs-buho-launchpad.html" class="help-nav-link">LaunchMe vs Buho Launchpad</a></li>
+                    </ul>
+                </nav>
+            </aside>
+        </div>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-inner">
+            <a href="/" class="brand small"><img class="brand-img" src="../images/logoicontext.png" alt="LaunchMe"></a>
+            <!-- Canonical URLs for SEO -->
+            <nav class="footer-nav" aria-label="Footer">
+                <a href="/support/">Support</a>
+                <a href="/privacy/">Privacy Policy</a>
+                <a href="/help/">Help Center</a>
+                <a href="/blog/">Blog</a>
+                <a href="/press-assets/">Press Assets</a>
+            </nav>
+        </div>
+    </footer>
+
+    <script src="../js/comparison-table.js"></script>
+    <script src="../js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Add a new comparison article (blog/launchme-vs-raycast.html) with SEO metadata, JSON-LD structured data, GA tracking, and a comparison-table hook to compare LaunchMe and Raycast. Update comparison-data.json to add "Customizable Grid with apps" and "Extensions ecosystem", remove/clean up outdated entries, and register Raycast as a competitor with feature overrides. Update blog/index.html to surface the new article via a blog card and add a navigation link to the article. This brings Raycast into the automated comparison table and publishes the macOS 26 Tahoe–focused comparison content.