### PR TITLE
Release LaunchMe version 2.002.0

### DIFF
--- a/account/index.html
+++ b/account/index.html
@@ -31,7 +31,7 @@
         <div class="container lp-header__inner">
             <a class="lp-logo" href="/"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
             <nav class="lp-nav lp-nav--account">
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="account-header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="account-header">Download</a>
             </nav>
         </div>
     </header>
@@ -59,7 +59,7 @@
             </section>
             <section class="account-card">
                 <h2>Need the app?</h2>
-                <p><a class="button primary" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a></p>
+                <p><a class="button primary" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a></p>
                 <p><a href="/">← Back to LaunchMe home</a></p>
             </section>
         </div>

--- a/blog/how-to-get-launchpad-back-on-macos-26-tahoe.html
+++ b/blog/how-to-get-launchpad-back-on-macos-26-tahoe.html
@@ -117,7 +117,7 @@
                     <p>When it comes to customization, you can use a lot of features LaunchMe provides you such as Dynamic and Live Wallpaper, many Widgets, custom app icons or Clear Colored icons that even Apple doesn't have in their OS.</p>
 
                     <div class="cta-group" style="justify-content: center; margin: 24px 0;">
-                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="article-inline">
+                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="article-inline">
                             <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                             Download for macOS
                         </a>
@@ -161,7 +161,7 @@
                             <div class="cta-pill">
                                 <div class="cta-pill__left">
                                     <h3 class="cta-pill__title">Get LaunchMe<br>and launch apps like a pro</h3>
-                                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="article-bottom-cta">
+                                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="article-bottom-cta">
                                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                                         Download for macOS
                                     </a>
@@ -197,7 +197,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -236,7 +236,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/index.html
+++ b/blog/index.html
@@ -257,7 +257,7 @@
             <!-- Sidebar -->
             <aside class="help-sidebar blog-sidebar" aria-label="Blog articles">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="blog-sidebar">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="blog-sidebar">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -298,7 +298,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-update-1-111.html
+++ b/blog/launchme-update-1-111.html
@@ -197,7 +197,7 @@
 
                     <!-- Download on the App Store CTA (same as How to Get Launchpad article) -->
                     <div class="cta-group" style="justify-content: center; margin: 24px 0;">
-                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="article-inline">
+                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="article-inline">
                             <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                             Download for macOS
                         </a>
@@ -217,7 +217,7 @@
                             <div class="cta-pill">
                                 <div class="cta-pill__left">
                                     <h3 class="cta-pill__title">Get LaunchMe<br>and launch apps like a pro</h3>
-                                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="article-bottom-cta">
+                                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="article-bottom-cta">
                                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                                         Download for macOS
                                     </a>
@@ -239,7 +239,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -278,7 +278,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-update-1-118.html
+++ b/blog/launchme-update-1-118.html
@@ -181,7 +181,7 @@
                     <p>If LaunchMe felt heavy with a huge grid before, this release cycle is worth updating for.</p>
 
                     <div class="cta-group" style="justify-content: center; margin: 24px 0;">
-                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="article-inline">
+                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="article-inline">
                             <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                             Download for macOS
                         </a>
@@ -217,7 +217,7 @@
                             <div class="cta-pill">
                                 <div class="cta-pill__left">
                                     <h3 class="cta-pill__title">Get LaunchMe<br>and launch apps like a pro</h3>
-                                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="article-bottom-cta">
+                                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="article-bottom-cta">
                                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                                         Download for macOS
                                     </a>
@@ -240,7 +240,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -280,7 +280,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-update-2-0-notch.html
+++ b/blog/launchme-update-2-0-notch.html
@@ -170,7 +170,7 @@
                     </figure>
 
                     <div class="cta-group" style="justify-content: center; margin: 24px 0;">
-                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="article-inline">
+                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="article-inline">
                             <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                             Download for macOS
                         </a>
@@ -193,7 +193,7 @@
                             <div class="cta-pill">
                                 <div class="cta-pill__left">
                                     <h3 class="cta-pill__title">Get LaunchMe<br>and launch apps like a pro</h3>
-                                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="article-bottom-cta">
+                                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="article-bottom-cta">
                                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                                         Download for macOS
                                     </a>
@@ -216,7 +216,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -256,7 +256,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-vs-appgrid.html
+++ b/blog/launchme-vs-appgrid.html
@@ -124,7 +124,7 @@
                     </p>
                     <p>
                         Sources:
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>,
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>,
                         <a class="faq-link" href="https://appgridmac.com">AppGrid official website</a>.
                     </p>
 
@@ -187,7 +187,7 @@
 
                     <p>
                         You can download LaunchMe on the
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>
                         and try Pro features free for 7 days.
                     </p>
 
@@ -202,7 +202,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -241,7 +241,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-vs-apphub.html
+++ b/blog/launchme-vs-apphub.html
@@ -123,7 +123,7 @@
                     </p>
                     <p>
                         Source:
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>.
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>.
                     </p>
 
                     <h2>Where AppHub falls behind</h2>
@@ -188,7 +188,7 @@
 
                     <p>
                         You can download LaunchMe on the
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>
                         and try Pro features free for 7 days.
                     </p>
 
@@ -203,7 +203,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -242,7 +242,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-vs-buho-launchpad.html
+++ b/blog/launchme-vs-buho-launchpad.html
@@ -123,7 +123,7 @@
                     </p>
                     <p>
                         Sources:
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>,
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>,
                         <a class="faq-link" href="https://www.drbuho.com/buholaunchpad">BuhoLaunchpad official page</a>.
                     </p>
 
@@ -183,7 +183,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -222,7 +222,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-vs-folderx.html
+++ b/blog/launchme-vs-folderx.html
@@ -123,7 +123,7 @@
                     </p>
                     <p>
                         Sources:
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>,
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>,
                         <a class="faq-link" href="https://apps.apple.com/us/app/folderx-menubar-launchpad/id6466177414?mt=12">FolderX - Menubar Launchpad</a>.
                     </p>
 
@@ -189,7 +189,7 @@
 
                     <p>
                         You can download LaunchMe on the
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>
                         and try Pro features free for 7 days.
                     </p>
 
@@ -204,7 +204,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -243,7 +243,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-vs-hotlaunch.html
+++ b/blog/launchme-vs-hotlaunch.html
@@ -123,7 +123,7 @@
                     </p>
                     <p>
                         Sources:
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>,
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>,
                         <a class="faq-link" href="https://apps.apple.com/us/app/hotlaunch-app-launchpad/id1570656803?mt=12">HotLaunch - App Launchpad</a>.
                     </p>
 
@@ -190,7 +190,7 @@
 
                     <p>
                         You can download LaunchMe on the
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>
                         and try Pro features free for 7 days.
                     </p>
 
@@ -205,7 +205,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -244,7 +244,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-vs-launchie.html
+++ b/blog/launchme-vs-launchie.html
@@ -126,7 +126,7 @@
                     </p>
                     <p>
                         Source:
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>.
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>.
                     </p>
 
                     <h2>Why LaunchMe wins for organization and daily workflow</h2>
@@ -226,7 +226,7 @@
                     </p>
 
                     <p>
-                        You can <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">download LaunchMe</a> from this site
+                        You can <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">download LaunchMe</a> from this site
                         and try Pro features free for 7 days to find the perfect setup for your workflow.
                     </p>
 
@@ -241,7 +241,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -280,7 +280,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-vs-launchos.html
+++ b/blog/launchme-vs-launchos.html
@@ -123,7 +123,7 @@
                     </p>
                     <p>
                         Sources:
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>,
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>,
                         <a class="faq-link" href="https://launchosapp.com">LaunchOS official website</a>,
                         <a class="faq-link" href="https://launchosapp.com/blog/en/why-we-built-launchos">Why we built LaunchOS</a>.
                     </p>
@@ -197,7 +197,7 @@
 
                     <p>
                         You can download LaunchMe on the
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>
                         and try Pro features free for 7 days.
                     </p>
 
@@ -212,7 +212,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -251,7 +251,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-vs-qal-pro.html
+++ b/blog/launchme-vs-qal-pro.html
@@ -123,7 +123,7 @@
                     </p>
                     <p>
                         Sources:
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>,
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>,
                         <a class="faq-link" href="https://apps.apple.com/us/app/quick-app-launcher-qal-pro/id6740396517?mt=12">Quick App Launcher (QAL) Pro on Mac App Store</a>.
                     </p>
 
@@ -189,7 +189,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -228,7 +228,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/blog/launchme-vs-raycast.html
+++ b/blog/launchme-vs-raycast.html
@@ -129,7 +129,7 @@
 
                     <p>
                         Sources:
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>,
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>,
                         <a class="faq-link" href="https://www.raycast.com">Raycast official website</a>,
                         <a class="faq-link" href="https://www.raycast.com/pro">Raycast Pro page</a>.
                     </p>
@@ -243,7 +243,7 @@
 
                     <p>
                         You can download LaunchMe on the
-                        <a class="faq-link" href="/updates/LaunchMeDirect-2.001.1.dmg">Download LaunchMe</a>
+                        <a class="faq-link" href="/updates/LaunchMeDirect-2.002.0.dmg">Download LaunchMe</a>
                         and try Pro features free for 7 days.
                     </p>
 
@@ -258,7 +258,7 @@
 
             <aside class="help-sidebar blog-sidebar" aria-label="Article navigation">
                 <section class="blog-subscribe" style="margin-bottom: 20px;">
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="download-badge">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -298,7 +298,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/help/direct/index.html
+++ b/help/direct/index.html
@@ -50,7 +50,7 @@
                 <a class="lp-nav__link" href="/#features">Features</a>
                 <a class="lp-nav__link" href="/#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/" data-ga="nav-pricing" data-ga-area="header">Pricing</a>
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="help-direct-header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="help-direct-header">Download</a>
             </nav>
         </div>
     </header>
@@ -68,7 +68,7 @@
                     <h2 class="help-coming-soon__title">Coming soon</h2>
                     <p class="help-coming-soon__text">We are writing step-by-step guides for the direct download build. Check the latest update notes or contact support if you need help right now.</p>
                     <div class="help-coming-soon__actions">
-                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="help-direct-coming-soon">
+                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="help-direct-coming-soon">
                             <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                             Download for macOS
                         </a>
@@ -113,7 +113,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/help/index.html
+++ b/help/index.html
@@ -63,7 +63,7 @@
                 <a class="lp-nav__link" href="/#features">Features</a>
                 <a class="lp-nav__link" href="/#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/" data-ga="nav-pricing" data-ga-area="header">Pricing</a>
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="help-header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="help-header">Download</a>
             </nav>
         </div>
     </header>
@@ -97,7 +97,7 @@
                     <p><strong>Please download LaunchMe directly from our website.</strong> When you install the new build, all your settings and layouts stay in place.</p>
                     <p>If you purchased <strong>Lifetime PRO</strong> on the Mac App Store, email <a href="mailto:team@launchmeapp.com">team@launchmeapp.com</a> and we will activate PRO in the direct-download version for you.</p>
                     <p>
-                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="help-important-update">
+                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="help-important-update">
                             <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                             Download for macOS
                         </a>
@@ -485,7 +485,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
         "@type": "Offer",
         "price": "0",
         "priceCurrency": "USD",
-        "url": "https://launchmeapp.com/updates/LaunchMeDirect-2.001.1.dmg"
+        "url": "https://launchmeapp.com/updates/LaunchMeDirect-2.002.0.dmg"
       },
       "url": "https://launchmeapp.com/",
       "image": "https://launchmeapp.com/images/website-preview.jpg",
@@ -118,7 +118,7 @@
                 <a class="lp-nav__link" href="#features">Features</a>
                 <a class="lp-nav__link" href="#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/" data-ga="nav-pricing" data-ga-area="header">Pricing</a>
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="header">Download</a>
             </nav>
         </div>
     </header>
@@ -140,7 +140,7 @@
                 <p class="hero-sub">LaunchMe brings automations, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 26 & 27.</p>
                 <div class="cta-group">
                     <!-- LAUNCHME_HERO_CTA_BEGIN -->
-                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="hero">
+                    <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="hero">
                         <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                         Download for macOS
                     </a>
@@ -1111,7 +1111,7 @@
                 <div class="cta-pill">
                     <div class="cta-pill__left">
                         <h3 class="cta-pill__title">Get LaunchMe<br>and launch apps like a pro</h3>
-                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="cta-bottom">
+                        <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="cta-bottom">
                             <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                             Download for macOS
                         </a>
@@ -1137,7 +1137,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/landing/index.html
+++ b/landing/index.html
@@ -32,7 +32,7 @@
                 <a class="lp-nav__link" href="#features">Features</a>
                 <a class="lp-nav__link" href="#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/">Pricing</a>
-                <a class="lp-btn" href="/updates/LaunchMeDirect-2.001.1.dmg">Download</a>
+                <a class="lp-btn" href="/updates/LaunchMeDirect-2.002.0.dmg">Download</a>
             </nav>
         </div>
     </header>
@@ -45,7 +45,7 @@
             <h1 class="hero__title">The Launchpad replacement<br>macOS 26 Tahoe deserves</h1>
             <p class="hero__sub">Customize it, search your files, and make it work your way.</p>
             <div class="hero__cta">
-                <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg">Download for macOS</a>
+                <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg">Download for macOS</a>
                 <a class="lp-btn lp-btn--ghost" href="/pricing/">See pricing &rsaquo;</a>
             </div>
             <p class="hero__note">Free to use · Works on macOS 26 Tahoe</p>
@@ -357,7 +357,7 @@
             <div class="final-cta">
                 <img class="app-icon" src="/images/logo-icon.png" alt="LaunchMe app icon">
                 <h2>Get LaunchMe and launch apps like a pro</h2>
-                <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.001.1.dmg">Download for macOS</a>
+                <a class="lp-btn lp-btn--lg" href="/updates/LaunchMeDirect-2.002.0.dmg">Download for macOS</a>
             </div>
         </section>
     </main>

--- a/press-assets/index.html
+++ b/press-assets/index.html
@@ -248,7 +248,7 @@
                 <a class="lp-nav__link" href="/#features">Features</a>
                 <a class="lp-nav__link" href="/#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/" data-ga="nav-pricing" data-ga-area="header">Pricing</a>
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="press-header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="press-header">Download</a>
             </nav>
         </div>
     </header>
@@ -407,7 +407,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -49,7 +49,7 @@
                 <a class="lp-nav__link" href="/#features">Features</a>
                 <a class="lp-nav__link" href="/#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/" data-ga="nav-pricing" data-ga-area="header" aria-current="page">Pricing</a>
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="pricing-header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="pricing-header">Download</a>
             </nav>
         </div>
     </header>
@@ -341,7 +341,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -50,7 +50,7 @@
                 <a class="lp-nav__link" href="/#features">Features</a>
                 <a class="lp-nav__link" href="/#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/" data-ga="nav-pricing" data-ga-area="header">Pricing</a>
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="privacy-header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="privacy-header">Download</a>
             </nav>
         </div>
     </header>
@@ -170,7 +170,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/refunds/index.html
+++ b/refunds/index.html
@@ -49,7 +49,7 @@
                 <a class="lp-nav__link" href="/#features">Features</a>
                 <a class="lp-nav__link" href="/#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/" data-ga="nav-pricing" data-ga-area="header">Pricing</a>
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="refunds-header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="refunds-header">Download</a>
             </nav>
         </div>
     </header>
@@ -114,7 +114,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/scripts/site-config.mjs
+++ b/scripts/site-config.mjs
@@ -6,7 +6,7 @@
  *
  * Bump DMG_FILENAME when you ship a new website-hosted build.
  */
-export const DMG_FILENAME = 'LaunchMeDirect-2.001.1.dmg';
+export const DMG_FILENAME = 'LaunchMeDirect-2.002.0.dmg';
 export const DMG_PATH = `/updates/${DMG_FILENAME}`;
 export const SITE_ORIGIN = 'https://launchmeapp.com';
 export const DMG_ABS_URL = `${SITE_ORIGIN}${DMG_PATH}`;

--- a/support/index.html
+++ b/support/index.html
@@ -60,7 +60,7 @@
                 <a class="lp-nav__link" href="/#features">Features</a>
                 <a class="lp-nav__link" href="/#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/" data-ga="nav-pricing" data-ga-area="header">Pricing</a>
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="support-header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="support-header">Download</a>
             </nav>
         </div>
     </header>
@@ -113,7 +113,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/terms/index.html
+++ b/terms/index.html
@@ -49,7 +49,7 @@
                 <a class="lp-nav__link" href="/#features">Features</a>
                 <a class="lp-nav__link" href="/#customization">Customization</a>
                 <a class="lp-nav__link" href="/pricing/" data-ga="nav-pricing" data-ga-area="header">Pricing</a>
-                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="terms-header">Download</a>
+                <a class="lp-btn lp-nav__download" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="terms-header">Download</a>
             </nav>
         </div>
     </header>
@@ -154,7 +154,7 @@
                 <a href="/" class="footer-logo"><img src="/images/logoicontext.png" alt="LaunchMe"></a>
                 <p class="footer-tagline">Your full-screen Mac launcher</p>
                 <p class="footer-desc">LaunchMe brings automation, file search, live wallpapers, widgets, and deep customization into one beautiful full-screen launcher built for macOS 27.</p>
-                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.001.1.dmg" data-ga="direct-dmg" data-ga-area="footer">
+                <a class="lp-btn lp-btn--lg footer-cta" href="/updates/LaunchMeDirect-2.002.0.dmg" data-ga="direct-dmg" data-ga-area="footer">
                     <svg class="apple-glyph" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
                     Download for macOS
                 </a>

--- a/updates/appcast.xml
+++ b/updates/appcast.xml
@@ -7,27 +7,24 @@
     <language>en</language>
     <!-- Newest release first (Sparkle reads the feed and picks the latest matching item). -->
     <item>
-      <title>Version 2.001.1</title>
-      <pubDate>Mon, 06 Jul 2026 08:54:33 +0000</pubDate>
-      <sparkle:version>126</sparkle:version>
-      <sparkle:shortVersionString>2.001.1</sparkle:shortVersionString>
+      <title>Version 2.002.0</title>
+      <pubDate>Thu, 09 Jul 2026 07:51:25 +0000</pubDate>
+      <sparkle:version>130</sparkle:version>
+      <sparkle:shortVersionString>2.002.0</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <description><![CDATA[
         <h3>What's new</h3>
         <ul>
-          <li>New feature - Notch. Widgets, Clipboard, Airdrop, Pocket, Timer, Spaces sync, Apps, Folders and much more!</li>
-          <li>Music Widget supports Apple Music animated art in Full Cover Style for all sizes in Notch and main grid</li>
-          <li>Gesture with Finger Spread now closes LaunchMe</li>
-          <li>Fixed Music Widget bug that used too much CPU and Power</li>
-          <li>Fixed hidden apps unhide after restart Mac or in other cases</li>
-          <li>Fixed gesture might not working after Sleep until you turn it Off/On</li>
-          <li>2.001.1 Fix: Spaces optimization in Notch</li>
+          <li>New Widget - Clock 11 styles</li>
+          <li>Updated Calendar Widget (soon more updates)</li>
+          <li>Pages animation optimization and improvements</li>
+          <li>Fixed hiden apps in Spaces were coming back after restart</li>
         </ul>
       ]]></description>
         <enclosure
-          url="https://launchmeapp.com/updates/LaunchMeDirect-2.001.1.dmg"
-          sparkle:edSignature="StIzhwSx/dLkSW6pgz+qwuGdBL8J5SkBNI+Mlu0JZOA5nHQj7gaT0A5MmCb6j/gR6Vmfvd9RRxvylO9fhBx7Ag=="
-          length="32676557"
+          url="https://launchmeapp.com/updates/LaunchMeDirect-2.002.0.dmg"
+          sparkle:edSignature="PseaYEPZOX+o+IuS/qXS1XAHa0m1qJaPFAAMYwUH9gqu8aAK0g1T01reGaIJZtoAfcgwYRlyE0qbc6/fUOvhDg=="
+          length="33206908"
           type="application/x-apple-diskimage"/>
       </item>
   </channel>


### PR DESCRIPTION
Update all download links and configuration to point to LaunchMe 2.002.0. This release includes a new Clock widget with 11 styles, updated Calendar widget, page animation improvements, and bug fixes for hidden apps in Spaces.